### PR TITLE
Allow more env var configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ The following enviroment variables can be configured:
 * `HEAL_MUST_WAIT_FOR_INITIAL_SYNC`: set to 'false' if you don't want this. (Mainly for debugging purposes)
 * `ENABLE_DUMP_FILE_CREATION`: set to 'false' if you don't want this
 * `ENABLE_HEALING_JOB_OPERATION`: set to 'false' if you don't want this
+* `INITIAL_PUBLICATION_GRAPH_SYNC_TASK_OPERATION`: The initial sync task operation, defaults to `http://redpencil.data.gift/id/jobs/concept/TaskOperation/deltas/initialPublicationGraphSyncing`
+* `DUMP_FILE_CREATION_TASK_OPERATION`: The dump file task operation, defaults to `http://redpencil.data.gift/id/jobs/concept/TaskOperation/deltas/deltaDumpFileCreation`
+* `HEALING_TASK_OPERATION`: The healing task operation, defaults to `http://redpencil.data.gift/id/jobs/concept/TaskOperation/deltas/patchPublicationGraph`
 
 ### API
 There is an api, mainly meant for debugging. Look at `app.js` if you want to use it.

--- a/env-config.js
+++ b/env-config.js
@@ -15,7 +15,7 @@ export const STATUS_SUCCESS = 'http://redpencil.data.gift/id/concept/JobStatus/s
 export const STATUS_SCHEDULED = 'http://redpencil.data.gift/id/concept/JobStatus/scheduled';
 export const STATUS_FAILED = 'http://redpencil.data.gift/id/concept/JobStatus/failed';
 export const STATUS_CANCELED = 'http://redpencil.data.gift/id/concept/JobStatus/canceled';
-export const ERROR_TYPE= 'http://open-services.net/ns/core#Error';
+export const ERROR_TYPE = 'http://open-services.net/ns/core#Error';
 export const DELTA_ERROR_TYPE = 'http://redpencil.data.gift/vocabularies/deltas/Error';
 
 export const JOB_TYPE = 'http://vocab.deri.ie/cogs#Job';
@@ -33,13 +33,13 @@ export const CRON_PATTERN_HEALING_JOB  = process.env.CRON_PATTERN_HEALING_JOB ||
 export const CRON_PATTERN_DUMP_JOB = process.env.CRON_PATTERN_DUMP_JOB || '0 0 0 * * *'; // every day at midnight
 
 // delta-initial-publication-graph-sync-job
-export const INITIAL_PUBLICATION_GRAPH_SYNC_TASK_OPERATION = 'http://redpencil.data.gift/id/jobs/concept/TaskOperation/deltas/initialPublicationGraphSyncing';
+export const INITIAL_PUBLICATION_GRAPH_SYNC_TASK_OPERATION = process.env.INITIAL_PUBLICATION_GRAPH_SYNC_TASK_OPERATION || 'http://redpencil.data.gift/id/jobs/concept/TaskOperation/deltas/initialPublicationGraphSyncing';
 
 // delta-dump-file-creation-job
-export const DUMP_FILE_CREATION_TASK_OPERATION = 'http://redpencil.data.gift/id/jobs/concept/TaskOperation/deltas/deltaDumpFileCreation';
+export const DUMP_FILE_CREATION_TASK_OPERATION = process.env.DUMP_FILE_CREATION_TASK_OPERATION || 'http://redpencil.data.gift/id/jobs/concept/TaskOperation/deltas/deltaDumpFileCreation';
 
 // delta-healing-job
-export const HEALING_TASK_OPERATION = 'http://redpencil.data.gift/id/jobs/concept/TaskOperation/deltas/healing/patchPublicationGraph';
+export const HEALING_TASK_OPERATION = process.env.HEALING_TASK_OPERATION || 'http://redpencil.data.gift/id/jobs/concept/TaskOperation/deltas/healing/patchPublicationGraph';
 
 // Configure initial sync parameters
 export const START_INITIAL_SYNC = process.env.START_INITIAL_SYNC == 'false' ? false : true ;

--- a/jobs/initial-sync-publication-graph.js
+++ b/jobs/initial-sync-publication-graph.js
@@ -3,17 +3,22 @@ import { STATUS_BUSY,
          INITIAL_PUBLICATION_GRAPH_SYNC_JOB_OPERATION,
          INITIAL_PUBLICATION_GRAPH_SYNC_TASK_OPERATION,
          DUMP_FILE_CREATION_JOB_OPERATION,
-         HEALING_JOB_OPERATION
+         HEALING_JOB_OPERATION,
+         ENABLE_DUMP_FILE_CREATION,
+         ENABLE_HEALING_JOB_OPERATION
        } from '../env-config.js';
 import { getJobs, storeError, createJob, scheduleTask } from '../lib/utils';
 
 export async function run(){
   console.info(`Starting ${INITIAL_PUBLICATION_GRAPH_SYNC_JOB_OPERATION} at ${new Date().toISOString()}`);
   try {
-
     let activeJobs = await getJobs(INITIAL_PUBLICATION_GRAPH_SYNC_JOB_OPERATION);
-    activeJobs = [...activeJobs, ...await getJobs(DUMP_FILE_CREATION_JOB_OPERATION, [ STATUS_BUSY, STATUS_SCHEDULED ] ) ];
-    activeJobs = [...activeJobs, ...await getJobs(HEALING_JOB_OPERATION, [ STATUS_BUSY, STATUS_SCHEDULED ] ) ];
+    if (ENABLE_DUMP_FILE_CREATION) {
+      activeJobs = [...activeJobs, ...await getJobs(DUMP_FILE_CREATION_JOB_OPERATION, [ STATUS_BUSY, STATUS_SCHEDULED ] ) ];
+    }
+    if (ENABLE_HEALING_JOB_OPERATION) {
+      activeJobs = [...activeJobs, ...await getJobs(HEALING_JOB_OPERATION, [ STATUS_BUSY, STATUS_SCHEDULED ] ) ];
+    }
 
     if(activeJobs.length){
       const message = `Incompatible jobs for


### PR DESCRIPTION
This service can be useful to organize jobs, not only delta-related. A concrete example I'm having now is: organize initial and healing sync jobs for a sync between a db and a sharepoint list. Being able to update more variables allows to better reflect the purpose of the generated jobs.