### PR TITLE
Add support for config override

### DIFF
--- a/app.js
+++ b/app.js
@@ -25,33 +25,21 @@ async function init() {
   const configFile = fs.readFileSync(CONFIG_FILE_JSON);
   const config = JSON.parse(configFile);
 
-  // A valid, but empty JSON override config file will be present.
-  // As such, there is neither a need to check for the file's existence
-  // nor to verify whether it is a completely empty (and thus an invalid)
-  // JSON file.
-  let configOverrideFile = fs.readFileSync(CONFIG_OVERRIDE_FILE_JSON);
-  let configOverride = JSON.parse(configOverrideFile);
+  let configOverride = {};
+  if (fs.existsSync(CONFIG_OVERRIDE_FILE_JSON)) {
+    let configOverrideFile = fs.readFileSync(CONFIG_OVERRIDE_FILE_JSON);
+    configOverride = JSON.parse(configOverrideFile);
+  }
 
   for (let conf of config) {
-    // The JSON override config file has the following structure:
-    // {
-    //   "submissions": {
-    //     "startInitialSync": true
-    //   },
-    //   "worship-submissions": {
-    //     "startInitialSync": true
-    //   }
-    // }
-    //
     // The override values are fetched as follows:
     //  - Fetch current configuration name
     //  - Check whether this configuration has any overrides
     //  - If yes, loop over the keys and update the values in the configuration
     let serviceName = conf["name"];
-    if (serviceName != undefined) {
-      for (let key in configOverride[serviceName]) {
-        conf[key] = configOverride[serviceName][key];
-      }
+    let confOverrideEntry = configOverride[serviceName] || {};
+    for (let key in confOverrideEntry) {
+      conf[key] = confOverrideEntry[key];
     }
 
     ensureDefaultsConfig(conf);

--- a/env-config.js
+++ b/env-config.js
@@ -39,5 +39,6 @@ export const DUMP_FILE_CREATION_TASK_OPERATION = process.env.DUMP_FILE_CREATION_
 export const HEALING_TASK_OPERATION = process.env.HEALING_TASK_OPERATION || 'http://redpencil.data.gift/id/jobs/concept/TaskOperation/deltas/healing/patchPublicationGraph';
 
 export const CONFIG_FILE_JSON = "/config/config.json";
+export const CONFIG_OVERRIDE_FILE_JSON = "/config/config.override.json";
 
 export const JOB_TIMEOUT_MINUTES = process.env.JOB_TIMEOUT_MINUTES || false;

--- a/env-config.js
+++ b/env-config.js
@@ -39,6 +39,6 @@ export const DUMP_FILE_CREATION_TASK_OPERATION = process.env.DUMP_FILE_CREATION_
 export const HEALING_TASK_OPERATION = process.env.HEALING_TASK_OPERATION || 'http://redpencil.data.gift/id/jobs/concept/TaskOperation/deltas/healing/patchPublicationGraph';
 
 export const CONFIG_FILE_JSON = "/config/config.json";
-export const CONFIG_OVERRIDE_FILE_JSON = "/config/config.override.json";
+export const CONFIG_OVERRIDE_FILE_JSON = process.env.CONFIG_OVERRIDE_FILE_JSON || "/config/config.override.json";
 
 export const JOB_TIMEOUT_MINUTES = process.env.JOB_TIMEOUT_MINUTES || false;


### PR DESCRIPTION
## Ticket Number

DL-5580

## Ticket Description

When consolidating services into `delta-producer-publication-graph-maintainer` (most recently with `worship-submissions`), some configuration keys need to be specifically changed only on the QA and production servers.

Previously, this was easily done by adding entries in `docker-compose.override.yml`; however, the current method entails working around merge conflicts when pulling the changes on the server in addition to editing the main `config.json` file and making sure it looks intact.

In order to retain the override functionality, this PR adds support for a `config.override.json` file that contains any values a user wants overridden on their machine or on a remote server without having these changes tracked by git.

## How to Test

* Add the following to your `docker-compose.override.yml` inside `app-digitaal-loket`:
```
delta-producer-background-jobs-initiator:
  environment:
    NODE_ENV: "development"
  volumes:
    - /path/to/delta-producer-background-jobs-initiator/:/app/
```

* Add a `config.override.json` file inside `config/delta-producer/background-jobs-initiator/` in your local Loket repo folder with the following snippet:
```json
{
  "submissions": {
    "startInitialSync": true
  },
  "worship-submissions": {
    "startInitialSync": true
  }
}
```

* Add `console.log("Conf is," conf);` under `validateConfig(conf)` in `app.js` to validate whether the override values were correctly picked up.

If you test on the latest commit of the Loket development branch, `"submissions"` and `"worship-submissions"` should have `"startInitialSync"` set to `true` whereas `"persons-sensitive"` should still have `"startInitialSync"` set to `false`.

## Note

I will be adding a PR on `app-digitaal-loket` to add the override config files to `.gitignore`. However, I want to first see how this PR goes before proceeding further.